### PR TITLE
Fix HTML parsing

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+elixir 1.7.3
+erlang 21.0.8
+rust 1.28.0

--- a/lib/microdata.ex
+++ b/lib/microdata.ex
@@ -129,14 +129,9 @@ defmodule Microdata do
     doc = html |> Meeseeks.parse()
 
     strategies()
-    |> Enum.find_value(fn strategy ->
-      case strategy.parse_items(doc) do
-        items when items != [] -> items
-        _ -> nil
-      end
-    end)
+    |> Enum.flat_map(& &1.parse_items(doc))
     |> case do
-      items when not is_nil(items) ->
+      items when items != [] ->
         {:ok, %Document{items: items}}
 
       _ ->

--- a/lib/microdata/strategy/html_microdata.ex
+++ b/lib/microdata/strategy/html_microdata.ex
@@ -43,7 +43,7 @@ defmodule Microdata.Strategy.HTMLMicrodata do
     end
   end
 
-  defp parse_item(item, nest_level \\ 1) do
+  defp parse_item(item, nest_level) do
     item_model = %Item{
       id: item |> Meeseeks.attr("itemid") |> Helpers.parse_item_id(),
       types:

--- a/lib/microdata/strategy/json_ld.ex
+++ b/lib/microdata/strategy/json_ld.ex
@@ -84,6 +84,10 @@ defmodule Microdata.Strategy.JSONLD do
     end
   end
 
+  defp download_context("https://schema.org") do
+    read_locally("schema.org.json")
+  end
+
   defp download_context("http://schema.org") do
     read_locally("schema.org.json")
   end

--- a/lib/microdata/strategy/json_ld.ex
+++ b/lib/microdata/strategy/json_ld.ex
@@ -84,6 +84,14 @@ defmodule Microdata.Strategy.JSONLD do
     end
   end
 
+  defp download_context("https://schema.org/") do
+    read_locally("schema.org.json")
+  end
+
+  defp download_context("http://schema.org/") do
+    read_locally("schema.org.json")
+  end
+
   defp download_context("https://schema.org") do
     read_locally("schema.org.json")
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Microdata.MixProject do
   def project do
     [
       app: :microdata,
-      version: "0.1.7",
+      version: "0.1.8",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/_cache/html-recipe-with-ld-and-nesting.html
+++ b/test/_cache/html-recipe-with-ld-and-nesting.html
@@ -1,0 +1,737 @@
+<!DOCTYPE html>
+<html lang="en-US" prefix="og: http://ogp.me/ns#">
+<head >
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<script>var et_site_url='https://www.fooduzzi.com';var et_post_id='10649';function et_core_page_resource_fallback(a,b){"undefined"===typeof b&&(b=a.sheet.cssRules&&0===a.sheet.cssRules.length);b&&(a.onerror=null,a.onload=null,a.href?a.href=et_site_url+"/?et_core_page_resource="+a.id+et_post_id:a.src&&(a.src=et_site_url+"/?et_core_page_resource="+a.id+et_post_id))}
+</script><title>Hemp Heart Tabouli - Fooduzzi</title>
+
+<!-- This site is optimized with the Yoast SEO plugin v9.5 - https://yoast.com/wordpress/plugins/seo/ -->
+<meta name="description" content="This Hemp Heart Tabouli is a simple, no-cook vegan and gluten free tabouli made with hemp hearts! A protein- and nutrient-packed snack, lunch, or side!"/>
+<link rel="canonical" href="https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="Hemp Heart Tabouli - Fooduzzi" />
+<meta property="og:description" content="This Hemp Heart Tabouli is a simple, no-cook vegan and gluten free tabouli made with hemp hearts! A protein- and nutrient-packed snack, lunch, or side!" />
+<meta property="og:url" content="https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/" />
+<meta property="og:site_name" content="Fooduzzi" />
+<meta property="article:publisher" content="https://www.facebook.com/pages/Fooduzzi/761543773962006" />
+<meta property="article:section" content="Food" />
+<meta property="article:published_time" content="2018-08-20T10:00:05+00:00" />
+<meta property="article:modified_time" content="2018-08-19T22:39:33+00:00" />
+<meta property="og:updated_time" content="2018-08-19T22:39:33+00:00" />
+<meta property="og:image" content="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-7.jpg" />
+<meta property="og:image:secure_url" content="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-7.jpg" />
+<meta property="og:image:width" content="600" />
+<meta property="og:image:height" content="900" />
+<meta property="og:image:alt" content="hemp heart tabouli in a bowl" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:description" content="This Hemp Heart Tabouli is a simple, no-cook vegan and gluten free tabouli made with hemp hearts! A protein- and nutrient-packed snack, lunch, or side!" />
+<meta name="twitter:title" content="Hemp Heart Tabouli - Fooduzzi" />
+<meta name="twitter:site" content="@fooduzzi" />
+<meta name="twitter:image" content="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-7.jpg" />
+<meta name="twitter:creator" content="@fooduzzi" />
+<script type='application/ld+json'>{"@context":"https://schema.org","@type":"Person","url":"https://www.fooduzzi.com/","sameAs":["https://www.facebook.com/pages/Fooduzzi/761543773962006","https://instagram.com/fooduzzi/","https://www.pinterest.com/fooduzzi/","https://twitter.com/fooduzzi"],"@id":"#person","name":"Alexa [fooduzzi.com]"}</script>
+<script type='application/ld+json'>{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"item":{"@id":"https://www.fooduzzi.com/","name":"Home"}},{"@type":"ListItem","position":2,"item":{"@id":"https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/","name":"Hemp Heart Tabouli"}}]}</script>
+<!-- / Yoast SEO plugin. -->
+
+<link rel='dns-prefetch' href='//fonts.googleapis.com' />
+<link rel='dns-prefetch' href='//code.ionicframework.com' />
+<link rel='dns-prefetch' href='//s.w.org' />
+<link rel="alternate" type="application/rss+xml" title="Fooduzzi &raquo; Feed" href="https://www.fooduzzi.com/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Fooduzzi &raquo; Comments Feed" href="https://www.fooduzzi.com/comments/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Fooduzzi &raquo; Hemp Heart Tabouli Comments Feed" href="https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/feed/" />
+		<script type="text/javascript">
+			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/11\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/11\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.fooduzzi.com\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.9.9"}};
+			!function(a,b,c){function d(a,b){var c=String.fromCharCode;l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,a),0,0);var d=k.toDataURL();l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,b),0,0);var e=k.toDataURL();return d===e}function e(a){var b;if(!l||!l.fillText)return!1;switch(l.textBaseline="top",l.font="600 32px Arial",a){case"flag":return!(b=d([55356,56826,55356,56819],[55356,56826,8203,55356,56819]))&&(b=d([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]),!b);case"emoji":return b=d([55358,56760,9792,65039],[55358,56760,8203,9792,65039]),!b}return!1}function f(a){var c=b.createElement("script");c.src=a,c.defer=c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var g,h,i,j,k=b.createElement("canvas"),l=k.getContext&&k.getContext("2d");for(j=Array("flag","emoji"),c.supports={everything:!0,everythingExceptFlag:!0},i=0;i<j.length;i++)c.supports[j[i]]=e(j[i]),c.supports.everything=c.supports.everything&&c.supports[j[i]],"flag"!==j[i]&&(c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&c.supports[j[i]]);c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&!c.supports.flag,c.DOMReady=!1,c.readyCallback=function(){c.DOMReady=!0},c.supports.everything||(h=function(){c.readyCallback()},b.addEventListener?(b.addEventListener("DOMContentLoaded",h,!1),a.addEventListener("load",h,!1)):(a.attachEvent("onload",h),b.attachEvent("onreadystatechange",function(){"complete"===b.readyState&&c.readyCallback()})),g=c.source||{},g.concatemoji?f(g.concatemoji):g.wpemoji&&g.twemoji&&(f(g.twemoji),f(g.wpemoji)))}(window,document,window._wpemojiSettings);
+		</script>
+		<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='twenty-seven-pro-css'  href='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/themes/twenty-seven-pro/style.css?ver=1.1' type='text/css' media='all' />
+<style id='twenty-seven-pro-inline-css' type='text/css'>
+
+
+		a,
+		.archive-pagination a:hover,
+		.archive-pagination a:focus,
+		.archive-pagination .active a,
+		.entry-title a:focus,
+		.entry-title a:hover,
+		.genesis-nav-menu a:focus,
+		.genesis-nav-menu a:hover,
+		.genesis-nav-menu .current-menu-item > a,
+		.genesis-responsive-menu .genesis-nav-menu a:focus,
+		.genesis-responsive-menu .genesis-nav-menu a:hover,
+		.menu-toggle:focus,
+		.menu-toggle:hover,
+		.site-footer a:hover,
+		.site-footer a:focus,
+		.sub-menu-toggle:focus,
+		.sub-menu-toggle:hover {
+			color: #333333;
+		}
+		
+
+		button:focus,
+		button:hover,
+		input:focus[type="button"],
+		input:focus[type="reset"],
+		input:focus[type="submit"],
+		input:hover[type="button"],
+		input:hover[type="reset"],
+		input:hover[type="submit"],
+		.archive-pagination li a:focus,
+		.archive-pagination li a:hover,
+		.archive-pagination .active a,
+		.button:focus,
+		.button:hover {
+			background-color: #f17a82;
+			color: #333333;
+		}
+		
+</style>
+<link rel='stylesheet' id='et-gf-open-sans-css'  href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' type='text/css' media='all' />
+<link rel='stylesheet' id='et_monarch-css-css'  href='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/monarch/css/style.css?ver=1.3.18' type='text/css' media='all' />
+<link rel='stylesheet' id='twenty-seven-fonts-css'  href='//fonts.googleapis.com/css?family=Playfair+Display%3A400%7CQuattrocento+Sans%3A400%2C400i%2C700%2C700i&#038;ver=1.1' type='text/css' media='all' />
+<link rel='stylesheet' id='twenty-seven-ionicons-css'  href='//code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css?ver=1.1' type='text/css' media='all' />
+<link rel='stylesheet' id='simple-social-icons-font-css'  href='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/simple-social-icons/css/style.css?ver=3.0.0' type='text/css' media='all' />
+<link rel='stylesheet' id='sccss_style-css'  href='https://www.fooduzzi.com/?sccss=1&#038;ver=4.9.9' type='text/css' media='all' />
+<link rel='stylesheet' id='matcha-style-css'  href='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/matcha/style-global.css?ver=4.9.9' type='text/css' media='all' />
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
+<!--[if lt IE 9]>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/themes/genesis/lib/js/html5shiv.min.js?ver=3.7.3'></script>
+<![endif]-->
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/themes/twenty-seven-pro/js/global.js?ver=1.0.0'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/simple-social-icons/svgxuse.js?ver=1.1.21'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/matcha/scripts.js?ver=4.9.9'></script>
+<link rel='https://api.w.org/' href='https://www.fooduzzi.com/wp-json/' />
+<link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.fooduzzi.com/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.fooduzzi.com/wp-includes/wlwmanifest.xml" /> 
+<meta name="generator" content="WordPress 4.9.9" />
+<link rel='shortlink' href='https://www.fooduzzi.com/?p=10649' />
+<link rel="alternate" type="application/json+oembed" href="https://www.fooduzzi.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.fooduzzi.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;format=xml" />
+<!-- Hotjar Tracking Code for www.fooduzzi.com -->
+<script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:100187,hjsv:5};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');
+</script><script type='text/javascript' async defer src='//assets.pinterest.com/js/pinit.js' data-pin-hover='true'></script>
+<style type="text/css" id="et-bloom-custom-css">
+					.et_bloom .et_bloom_optin_3 .et_bloom_form_content { background-color: #ededed !important; } .et_bloom .et_bloom_optin_3 .et_bloom_form_container .et_bloom_form_header { background-color: #333333 !important; } .et_bloom .et_bloom_optin_3 .carrot_edge .et_bloom_form_content:before { border-top-color: #333333 !important; } .et_bloom .et_bloom_optin_3 .carrot_edge.et_bloom_form_right .et_bloom_form_content:before, .et_bloom .et_bloom_optin_3 .carrot_edge.et_bloom_form_left .et_bloom_form_content:before { border-top-color: transparent !important; border-left-color: #333333 !important; }
+						@media only screen and ( max-width: 767px ) {.et_bloom .et_bloom_optin_3 .carrot_edge.et_bloom_form_right .et_bloom_form_content:before, .et_bloom .et_bloom_optin_3 .carrot_edge.et_bloom_form_left .et_bloom_form_content:before { border-top-color: #333333 !important; border-left-color: transparent !important; }
+						}.et_bloom .et_bloom_optin_3 .et_bloom_form_content button { background-color: #2d2d2d !important; } .et_bloom .et_bloom_optin_3 .et_bloom_form_content button { background-color: #2d2d2d !important; } .et_bloom .et_bloom_optin_3 .et_bloom_form_container h2, .et_bloom .et_bloom_optin_3 .et_bloom_form_container h2 span, .et_bloom .et_bloom_optin_3 .et_bloom_form_container h2 strong { font-family: "Roboto", Helvetica, Arial, Lucida, sans-serif; }.et_bloom .et_bloom_optin_3 .et_bloom_form_container p, .et_bloom .et_bloom_optin_3 .et_bloom_form_container p span, .et_bloom .et_bloom_optin_3 .et_bloom_form_container p strong, .et_bloom .et_bloom_optin_3 .et_bloom_form_container form input, .et_bloom .et_bloom_optin_3 .et_bloom_form_container form button span { font-family: "Roboto", Helvetica, Arial, Lucida, sans-serif; } 
+				</style><style type="text/css" id="et-social-custom-css">
+				.et_monarch .et_social_sidebar_networks li, .et_monarch .et_social_mobile li { background: #ffffff; } .et_monarch .et_social_sidebar_networks .et_social_icons_container li:hover, .et_monarch .et_social_mobile .et_social_icons_container li:hover { background: #ffffff !important; } .et_social_sidebar_border li { border-color: #ffffff !important; } .et_monarch .et_social_sidebar_networks .et_social_icons_container li i, .et_monarch .et_social_sidebar_networks .et_social_icons_container li .et_social_count, .et_monarch .et_social_mobile .et_social_icons_container li i, .et_monarch .et_social_mobile .et_social_icons_container li .et_social_count { color: #333333; } .et_monarch .et_social_sidebar_networks .et_social_icons_container li:hover i, .et_monarch .et_social_sidebar_networks .et_social_icons_container li:hover .et_social_count, .et_monarch .et_social_mobile .et_social_icons_container li:hover i, .et_monarch .et_social_mobile .et_social_icons_container li:hover .et_social_count { color: #f17a82 !important; } 
+			</style><style type="text/css">
+.comment-form .tasty-recipes-ratings-buttons {
+  unicode-bidi: bidi-override;
+  direction: rtl;
+  text-align: center; }
+  .comment-form .tasty-recipes-ratings-buttons > span {
+    display: inline-block;
+    position: relative;
+    width: 1.1em; }
+    .comment-form .tasty-recipes-ratings-buttons > span i {
+      font-style: normal; }
+    .comment-form .tasty-recipes-ratings-buttons > span .unchecked {
+      display: inline-block; }
+    .comment-form .tasty-recipes-ratings-buttons > span .checked {
+      display: none; }
+  .comment-form .tasty-recipes-ratings-buttons > input:checked ~ span .unchecked {
+    display: none; }
+  .comment-form .tasty-recipes-ratings-buttons > input:checked ~ span .checked {
+    display: inline-block; }
+  .comment-form .tasty-recipes-ratings-buttons > input:checked ~ span:before .unchecked {
+    display: inline-block; }
+  .comment-form .tasty-recipes-ratings-buttons > input:checked ~ span:before .checked {
+    display: none; }
+  @media only screen and (min-width: 1024px) {
+    .comment-form .tasty-recipes-ratings-buttons > *:hover .unchecked,
+    .comment-form .tasty-recipes-ratings-buttons > *:hover ~ span .unchecked,
+    .comment-form .tasty-recipes-ratings-buttons:not(:hover) > input:checked ~ span .unchecked {
+      display: none; }
+    .comment-form .tasty-recipes-ratings-buttons > *:hover .checked,
+    .comment-form .tasty-recipes-ratings-buttons > *:hover ~ span .checked,
+    .comment-form .tasty-recipes-ratings-buttons:not(:hover) > input:checked ~ span .checked {
+      display: inline-block; }
+    .comment-form .tasty-recipes-ratings-buttons > *:hover:before .unchecked,
+    .comment-form .tasty-recipes-ratings-buttons > *:hover ~ span:before .unchecked,
+    .comment-form .tasty-recipes-ratings-buttons:not(:hover) > input:checked ~ span:before .unchecked {
+      display: inline-block; }
+    .comment-form .tasty-recipes-ratings-buttons > *:hover:before .checked,
+    .comment-form .tasty-recipes-ratings-buttons > *:hover ~ span:before .checked,
+    .comment-form .tasty-recipes-ratings-buttons:not(:hover) > input:checked ~ span:before .checked {
+      display: none; } }
+  .comment-form .tasty-recipes-ratings-buttons > input {
+    margin-left: -1.1em;
+    margin-right: 0;
+    top: 3px;
+    width: 1.1em;
+    height: 1.1em;
+    position: relative;
+    z-index: 2;
+    opacity: 0; }
+
+</style>
+<link rel="pingback" href="https://www.fooduzzi.com/xmlrpc.php" />
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-58401666-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-58401666-1');
+</script>
+
+<meta name="google-site-verification" content="0q1MGClI8bE-zmFvrmYK0jxb2-75ca24NkCIe6ZnyNo" />
+
+<meta name="google-site-verification" content="0q1MGClI8bE-zmFvrmYK0jxb2-75ca24NkCIe6ZnyNo" /><style type="text/css">.site-title a { background: url(https://www.fooduzzi.com/wp-content/uploads/2017/04/cropped-fooduzzi-2017.jpg) no-repeat !important; }</style>
+
+<!-- Begin Matcha custom styles. zeph.co/matcha -->
+<style>
+#matcha { background: #fff; }
+#matchaheader .mr-padding { padding: 40px 35px 0 35px; }
+#matcha h3 {  color: #111;  }
+#matcha h3:hover { color: #f17a82; -webkit-transition: all 100ms ease-out; -moz-transition: all 100ms ease-out; -o-transition: all 100ms ease-out; transition: all 100ms ease-out; }
+#matcha h4 { color: #111; }
+#matcha li:hover { color: #f17a82; }
+#matcha li a, #matcha p a { border-bottom: 1px solid #ccc; color: #111; }
+#matcha li a:hover, #matcha p a:hover { border-bottom: 1px solid #f17a82; }
+#matcha li:hover a, #matcha a:hover { color: #f17a82; }
+#matcha strong { color: #888; }
+#matcha .mr-branding { color: #888; border: 1px solid #fff; }
+#matcha .mr-branding:hover { color: #111; }
+#matcha .mr-print { border: 1px solid #ccc; color: #888; }
+#matcha .mr-print:hover { background: #f17a82; border-color: #f17a82; color: #fff; }
+#matcha .mr-branding, #matcha .mr-branding .mr-heart { color: #ccc; }
+#matcha .mr-branding:hover .mr-heart { color: #111; }
+#matcha ul { -webkit-column-count: 1; -moz-column-count: 1; -ms-column-count: 1; column-count: 1; }
+#matcha * { font-family: 'Roboto', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif; color: #111; }
+#matcha p, #matcha a, #matcha li, #matcha .matcha-brand, #matcha .matcha-print { font-size: 16px; font-weight: 300; color: #111; }
+#matcha table td { font-weight: 300; font-size: 15px; }
+#matcha h3 { font-size:31px; font-weight: 700; letter-spacing: 0px; }
+#matcha h4 { font-size:16px; font-weight: 500; color: #111; }
+#matcha { max-width: 650px; }
+#matcha { box-shadow: 0 2px 5px 0 rgba(0,0,0,.4); }
+#matcha .mr-print { border: 1px solid #ccc; box-shadow: 0 2px 3px 0 rgba(0,0,0,.4); }
+#matcha .mr-print:hover { box-shadow: 0 2px 10px 0 rgba(0,0,0,.25); }
+#matcha .mr-print:active, #matcha .mr-print:focus { box-shadow: none; -webkit-filter: brightness(90%); filter: brightness(90%); }
+@media only screen and (max-width: 550px) {
+#matcha { background: none; }
+#matcha h3 { color: #111; }
+#matcha table td, #matcha table td * { color: #111; }
+#matcha .mr-print, #matcha .mr-branding { color: #888; }
+#matcha .mr-print:hover { background: #fff; color: #f17a82; }
+}
+</style>
+<!-- End Matcha custom styles. zeph.co/matcha -->
+
+<link rel="icon" href="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2017/04/cropped-fooduzzi-favicon-2017-32x32.png" sizes="32x32" />
+<link rel="icon" href="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2017/04/cropped-fooduzzi-favicon-2017-192x192.png" sizes="192x192" />
+<link rel="apple-touch-icon-precomposed" href="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2017/04/cropped-fooduzzi-favicon-2017-180x180.png" />
+<meta name="msapplication-TileImage" content="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2017/04/cropped-fooduzzi-favicon-2017-270x270.png" />
+</head>
+<body class="post-template-default single single-post postid-10649 single-format-standard et_bloom unknown et_monarch custom-header header-image header-full-width sidebar-content" itemscope itemtype="https://schema.org/WebPage"><div class="site-container"><ul class="genesis-skip-link"><li><a href="#genesis-nav-primary" class="screen-reader-shortcut"> Skip to primary navigation</a></li><li><a href="#genesis-content" class="screen-reader-shortcut"> Skip to content</a></li><li><a href="#genesis-sidebar-primary" class="screen-reader-shortcut"> Skip to primary sidebar</a></li></ul><header class="site-header" itemscope itemtype="https://schema.org/WPHeader"><div class="wrap"><nav class="nav-primary" aria-label="Main" itemscope itemtype="https://schema.org/SiteNavigationElement" id="genesis-nav-primary"><div class="wrap"><ul id="menu-left-menu" class="menu genesis-nav-menu menu-primary js-superfish"><li id="menu-item-7917" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7917"><a href="https://www.fooduzzi.com/about/" itemprop="url"><span itemprop="name">About</span></a></li>
+<li id="menu-item-7918" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7918"><a href="https://www.fooduzzi.com/welcome-to-fooduzzi/" itemprop="url"><span itemprop="name">Start Here</span></a></li>
+<li id="menu-item-7919" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-has-children menu-item-7919"><a href="https://www.fooduzzi.com/category/food/" itemprop="url"><span itemprop="name">Recipes</span></a>
+<ul class="sub-menu">
+	<li id="menu-item-7929" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7929"><a href="https://www.fooduzzi.com/food-index/" itemprop="url"><span itemprop="name">Recipe Index</span></a></li>
+	<li id="menu-item-7930" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-7930"><a href="https://www.fooduzzi.com/category/breakfast/" itemprop="url"><span itemprop="name">Breakfast</span></a>
+	<ul class="sub-menu">
+		<li id="menu-item-7931" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-7931"><a href="https://www.fooduzzi.com/category/oats/" itemprop="url"><span itemprop="name">Oats</span></a></li>
+		<li id="menu-item-7932" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-7932"><a href="https://www.fooduzzi.com/category/smoothies/" itemprop="url"><span itemprop="name">Smoothies</span></a></li>
+	</ul>
+</li>
+	<li id="menu-item-7933" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-7933"><a href="https://www.fooduzzi.com/category/appetizers/" itemprop="url"><span itemprop="name">Appetizers</span></a></li>
+	<li id="menu-item-7934" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-has-children menu-item-7934"><a href="https://www.fooduzzi.com/category/entree/" itemprop="url"><span itemprop="name">Entree</span></a>
+	<ul class="sub-menu">
+		<li id="menu-item-10329" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-10329"><a href="https://www.fooduzzi.com/category/salad/" itemprop="url"><span itemprop="name">Salad</span></a></li>
+		<li id="menu-item-10330" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-10330"><a href="https://www.fooduzzi.com/category/sandwiches/" itemprop="url"><span itemprop="name">Sandwiches</span></a></li>
+		<li id="menu-item-10331" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-10331"><a href="https://www.fooduzzi.com/category/soup/" itemprop="url"><span itemprop="name">Soup</span></a></li>
+		<li id="menu-item-10332" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-10332"><a href="https://www.fooduzzi.com/category/sauces/" itemprop="url"><span itemprop="name">Sauces</span></a></li>
+	</ul>
+</li>
+	<li id="menu-item-7935" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-7935"><a href="https://www.fooduzzi.com/category/snack/" itemprop="url"><span itemprop="name">Snack</span></a></li>
+	<li id="menu-item-7936" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-7936"><a href="https://www.fooduzzi.com/category/dessert/" itemprop="url"><span itemprop="name">Dessert</span></a></li>
+	<li id="menu-item-7944" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-7944"><a href="#" itemprop="url"><span itemprop="name">Dietary Restriction</span></a>
+	<ul class="sub-menu">
+		<li id="menu-item-7942" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-7942"><a href="https://www.fooduzzi.com/category/vegan/" itemprop="url"><span itemprop="name">Vegan</span></a></li>
+		<li id="menu-item-7941" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-7941"><a href="https://www.fooduzzi.com/category/glutenfree/" itemprop="url"><span itemprop="name">Gluten Free</span></a></li>
+		<li id="menu-item-7943" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-7943"><a href="https://www.fooduzzi.com/category/vegetarian/" itemprop="url"><span itemprop="name">Vegetarian</span></a></li>
+	</ul>
+</li>
+	<li id="menu-item-7937" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-7937"><a href="https://www.fooduzzi.com/category/how-tos/" itemprop="url"><span itemprop="name">Kitchen How-Tos</span></a></li>
+	<li id="menu-item-7938" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-7938"><a href="https://www.fooduzzi.com/category/favorites/" itemprop="url"><span itemprop="name">Favorites</span></a>
+	<ul class="sub-menu">
+		<li id="menu-item-7939" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-7939"><a href="https://www.fooduzzi.com/category/favorites/alexa-favorites/" itemprop="url"><span itemprop="name">Alexa Favorites</span></a></li>
+		<li id="menu-item-7940" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-7940"><a href="https://www.fooduzzi.com/category/favorites/reader-favorites/" itemprop="url"><span itemprop="name">Reader Favorites</span></a></li>
+	</ul>
+</li>
+</ul>
+</li>
+</ul></div></nav><div class="title-area"><p class="site-title" itemprop="headline"><a href="https://www.fooduzzi.com/">Fooduzzi</a></p><p class="site-description" itemprop="description">the plant-based food blog</p></div><nav class="nav-secondary" aria-label="Secondary" itemscope itemtype="https://schema.org/SiteNavigationElement"><div class="wrap"><ul id="menu-right-menu" class="menu genesis-nav-menu menu-secondary js-superfish"><li id="menu-item-10134" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-10134"><a href="https://www.fooduzzi.com/category/life/" itemprop="url"><span itemprop="name">Life</span></a>
+<ul class="sub-menu">
+	<li id="menu-item-10135" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-10135"><a href="https://www.fooduzzi.com/category/life/travel/" itemprop="url"><span itemprop="name">Vegan Travel</span></a></li>
+</ul>
+</li>
+<li id="menu-item-7922" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7922"><a href="https://www.fooduzzi.com/work-with-me/" itemprop="url"><span itemprop="name">Work with Me</span></a></li>
+<li id="menu-item-7923" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-7923"><a href="mailto:fooduzzi@gmail.com" itemprop="url"><span itemprop="name">Contact</span></a></li>
+</ul></div></nav></div></header><div class="site-inner"><div class="content-sidebar-wrap"><main class="content" id="genesis-content"><article class="post-10649 post type-post status-publish format-standard has-post-thumbnail category-appetizers category-entree category-food category-glutenfree category-snack category-vegan category-vegetables category-vegetarian entry" itemscope itemtype="https://schema.org/CreativeWork"><header class="entry-header"><h1 class="entry-title" itemprop="headline">Hemp Heart Tabouli</h1>
+<p class="entry-meta"><time class="entry-time" itemprop="datePublished" datetime="2018-08-20T06:00:05+00:00">August 20, 2018</time> by <span class="entry-author" itemprop="author" itemscope itemtype="https://schema.org/Person"><a href="https://www.fooduzzi.com/author/peduzziagmail-com/" class="entry-author-link" itemprop="url" rel="author"><span class="entry-author-name" itemprop="name">Alexa [fooduzzi.com]</span></a></span> <span class="entry-comments-link"><a href="https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/#comments">1 Comment</a></span> </p><img width="600" height="900" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-7.jpg" class="attachment-post-image size-post-image wp-post-image" alt="hemp heart tabouli in a bowl" srcset="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-7.jpg 600w, https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-7-200x300.jpg 200w" sizes="(max-width: 600px) 100vw, 600px" data-pin-description="Hemp Heart Tabouli: A simple, no-cook vegan and gluten free tabouli made with hemp hearts! A protein- and nutrient-packed snack, lunch, or side! || fooduzzi.com recipe #hemphearts #tabouli #vegan #veganmeal" /></header><div class="entry-content" itemprop="text"><p>If you have a garden that is totally overgrown with parsley, mint, and tomatoes, this recipe is for you!</p>
+<p>This recipe is <em>also</em> for you if you&#8217;re a fan of delicious flavor.</p>
+<p>(name that show)<span id="more-10649"></span></p>
+<p><a href="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-6.jpg"><img class="aligncenter wp-image-10656 size-full" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-6.jpg" alt="a bunch of parsley" width="600" height="900" data-pin-description="Hemp Heart Tabouli: A simple, no-cook vegan and gluten free tabouli made with hemp hearts! A protein- and nutrient-packed snack, lunch, or side! || fooduzzi.com recipe #hemphearts #tabouli #vegan #veganmeal" srcset="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-6.jpg 600w, https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-6-200x300.jpg 200w" sizes="(max-width: 600px) 100vw, 600px" /></a></p>
+<p>I. Love. Tabouli. Or tabbouleh. However you spell it, I love it.</p>
+<p>There&#8217;s a fabulous Mediterranean restaurant chain here in Pittsburgh (Aladdin&#8217;s), and they have the best tabouli ever. They add it to this salad that I <em>swear</em> I&#8217;m not going to get again every time I go. But alas, I end up ordering it again and it never ever ever disappoints.</p>
+<p>Tabouli is typically made with bulgur wheat, buuuut I wanted to lay off the wheat a bit. I&#8217;ve been eating a ton of wheat in the form of bread, pizza, and pasta recently. Not like it&#8217;s a bad thing in moderation. But I am desperately missing some moderation in my life.</p>
+<p>And because I&#8217;ve been working out more recently, I&#8217;ve been looking for ways to increase my protein intake. And one of my favorite plant-based protein sources is&#8230;the hemp heart!</p>
+<p><a href="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-2.jpg"><img class="aligncenter wp-image-10660 size-full" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-2.jpg" alt="hemp hearts in a measuring cup" width="600" height="900" data-pin-description="Hemp Heart Tabouli: A simple, no-cook vegan and gluten free tabouli made with hemp hearts! A protein- and nutrient-packed snack, lunch, or side! || fooduzzi.com recipe #hemphearts #tabouli #vegan #veganmeal" srcset="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-2.jpg 600w, https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-2-200x300.jpg 200w" sizes="(max-width: 600px) 100vw, 600px" /></a></p>
+<h2>So, uh, what are hemp hearts?</h2>
+<p>Fab question, my dear. They are the creamy, nutty, delicious little seeds from the hemp plant!</p>
+<p><em>Yes</em>, that hemp plant. <em>No</em>, they won&#8217;t get you high.</p>
+<p>You can actually buy them in pretty much any grocery store. Typically over by the oats / cereals or over by the nuts and seeds. But they&#8217;re awesome. 3 Tbsp. of hemp hearts have 10g protein. Plus <a href="https://www.bobsredmill.com/hulled-hemp-seed-hearts.html">omega-3s and omega-6s</a> for healthy hearts and brains, iron, manganese, thiamine, and lots of other goodness.</p>
+<p>They&#8217;re a cute little nutritional powerhouse, and they&#8217;re delicious in this tabouli.</p>
+<p>But honestly, how could they <em>not</em> be delicious in this tabouli when there are ingredients like copious amounts of parsley, a bit of mint, some lemon juice, a bit of veggies, and a wee bit of seasoning?</p>
+<p>This is the kind of dish that just <em>shines</em> in its simplicity. It&#8217;s stupidly simple, but ridiculously flavorful and addictive.</p>
+<p><a href="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-9.jpg"><img class="aligncenter wp-image-10659 size-full" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-9.jpg" alt="hemp heart tabouli in bowl" width="600" height="900" data-pin-description="Hemp Heart Tabouli: A simple, no-cook vegan and gluten free tabouli made with hemp hearts! A protein- and nutrient-packed snack, lunch, or side! || fooduzzi.com recipe #hemphearts #tabouli #vegan #veganmeal" srcset="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-9.jpg 600w, https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-9-200x300.jpg 200w" sizes="(max-width: 600px) 100vw, 600px" /></a></p>
+<p>Wahoo! I highly suggest enjoying this tabouli in <a href="https://www.fooduzzi.com/2018/01/vegan-mediterranean-quinoa-falafel-salad/">salads</a>, on <a href="https://www.fooduzzi.com/2017/05/how-to-make-a-vegan-cheese-plate/">cheese plates</a>, with <a href="https://www.fooduzzi.com/2017/05/garlic-herb-almond-flour-crackers/">crackers</a>, in pitas, or on its own with a fork or spoon.</p>
+<p>I love it. You&#8217;ll love it. I know it.</p>
+
+    <!-- //////////////////////////////// -->
+    <!--        Begin Matcha Recipe       -->
+    <!--    https://www.zeph.co/matcha    -->
+    <!-- //////////////////////////////// -->
+
+    <div id="recipe">
+    	<div id="matcha" itemscope itemtype="http://schema.org/Recipe">
+
+            <!-- Open Matcha's Header -->
+    		<div id="matchaheader" class="mr-section">
+    			<div class="mr-image"></div>
+    			<div class="mr-section mr-padding">
+    				<h3 class="mr-section" itemprop="name">Hemp Heart Tabouli</h3>
+    				<div class="printMeta mr-hide">
+    					From <span itemprop="author">Fooduzzi</span>
+    					at <span itemprop="url">https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/</span><br><br>
+    				</div>
+                                            <img class="mr-print-image" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/hemp-heart-tabouli-7.jpg">
+                        <span class="mr-hide" itemprop="image">https://www.fooduzzi.com/wp-content/uploads/2018/08/hemp-heart-tabouli-7.jpg</span>
+                        				<table><tr><td>Prep: <time itemprop='prepTime' datetime='PT10M'>10m</time></td><td>Yield: <span itemprop="recipeYield">serves 4-6</span></td><td class='mr-hide'>Total: <time itemprop='totalTime' datetime='PT0H10M'>0h 10m</time></td></tr></table>    			</div>
+    		</div>
+
+            <!-- Open Matcha's Body -->
+    		<div class="matcha-body">
+                <div class="mr-section mr-padding">
+        			                    <div itemprop="description" class="mr-section mr-description">
+        				<p>A simple, no-cook vegan tabouli made with hemp hearts! A protein- and nutrient-packed snack, lunch, or side!</p>        			</div>
+                            			<div class="mr-section mr-ingredients">
+        				<h4>You'll Need...</h4>
+        				<ul>
+        					<li itemprop="recipeIngredient" class="matcha-li" onclick="matchaStrikethrough(this);">2 cups packed parsley, minced</li>
+<li itemprop='recipeIngredient' class='matcha-li' onclick='matchaStrikethrough(this);'>5 large mint leaves, minced</li>
+<li itemprop='recipeIngredient' class='matcha-li' onclick='matchaStrikethrough(this);'>1/2 cup hemp hearts</li>
+<li itemprop='recipeIngredient' class='matcha-li' onclick='matchaStrikethrough(this);'>juice of 1-2 small lemons</li>
+<li itemprop='recipeIngredient' class='matcha-li' onclick='matchaStrikethrough(this);'>1 roma tomato, chopped </li>
+<li itemprop='recipeIngredient' class='matcha-li' onclick='matchaStrikethrough(this);'>1 large green onion, minced</li>
+<li itemprop='recipeIngredient' class='matcha-li' onclick='matchaStrikethrough(this);'>1/4 large english cucumber, chopped</li>
+<li itemprop='recipeIngredient' class='matcha-li' onclick='matchaStrikethrough(this);'>1/4 tsp. allspice, optional for toasty flavor</li>
+<li itemprop='recipeIngredient' class='matcha-li' onclick='matchaStrikethrough(this);'>1 Tbsp. olive oil</li>
+<li itemprop='recipeIngredient' class='matcha-li' onclick='matchaStrikethrough(this);'>salt + pepper</li>        				</ul>
+        			</div>
+        			<div class="mr-section mr-directions">
+        				<h4>Directions</h4>
+        				<ol>
+        					<li itemprop="recipeInstructions" class="matcha-li" onclick="matchaStrikethrough(this);">Mix all of your ingredients in a medium bowl. Season with salt and pepper to taste and enjoy!</li>        				</ol>
+        			</div>
+                        				<div class="mr-section mr-footer">
+    					<a href="https://www.zeph.co/matcha" class="mr-branding" target="_blank">Generated with <span class="mr-heart">&#9829;&#xfe0e;</span> by Matcha</a>
+                                                    <a class="mr-print" onclick="printMatcha('recipe')">Print</a>
+                            				</div>
+        		</div>
+            </div>
+    	</div>
+    </div>
+    <!-- End Matcha -->
+<div class="et_bloom_below_post"><div class="et_bloom_inline_form et_bloom_optin et_bloom_make_form_visible et_bloom_optin_3" style="display: none;">
+				
+				<div class="et_bloom_form_container  with_edge carrot_edge et_bloom_rounded et_bloom_form_text_dark et_bloom_form_right et_bloom_inline_2_fields">
+					
+			<div class="et_bloom_form_container_wrapper clearfix">
+				<div class="et_bloom_header_outer">
+					<div class="et_bloom_form_header et_bloom_header_text_light">
+						<img width="610" height="160" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2017/04/fooduzzi-2017-no-background-white-610x160.png" class=" et_bloom_image_slideup et_bloom_image" alt="" srcset="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2017/04/fooduzzi-2017-no-background-white-610x160.png 610w, https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2017/04/fooduzzi-2017-no-background-white-300x79.png 300w, https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2017/04/fooduzzi-2017-no-background-white-768x201.png 768w, https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2017/04/fooduzzi-2017-no-background-white.png 1024w" sizes="(max-width: 610px) 100vw, 610px" />
+						<div class="et_bloom_form_text">
+						<h2 style="text-align: center;">Join the Fooduzzi Fam!</h2><p style="text-align: center;">I'll send you healthy takes on classic recipes, delectable recipe roundups, and more updates on my growing blog. You'll also receive a free eCookbook featuring my best recipes!</p>
+					</div>
+						
+					</div>
+				</div>
+				<div class="et_bloom_form_content et_bloom_2_fields">
+					
+					
+					<form method="post" class="clearfix">
+						<p class="et_bloom_popup_input et_bloom_subscribe_name">
+								<input placeholder="First Name" maxlength="50">
+							</p>
+						<p class="et_bloom_popup_input et_bloom_subscribe_email">
+							<input placeholder="Email">
+						</p>
+
+						<button data-optin_id="optin_3" data-service="mailchimp" data-list_id="91657c27d5" data-page_id="10649" data-account="peduzzia" data-disable_dbl_optin="" class="et_bloom_submit_subscription">
+							<span class="et_bloom_subscribe_loader"></span>
+							<span class="et_bloom_button_text et_bloom_button_text_color_light">Send me healthy recipes!</span>
+						</button>
+					</form>
+					<div class="et_bloom_success_container">
+						<span class="et_bloom_success_checkmark"></span>
+					</div>
+					<h2 class="et_bloom_success_message">Check your email to confirm and to download your free eCookbook!</h2>
+					
+				</div>
+			</div>
+			<span class="et_bloom_close_button"></span>
+				</div>
+			</div></div><span class="et_social_bottom_trigger"></span><!--<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+			xmlns:dc="http://purl.org/dc/elements/1.1/"
+			xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/">
+		<rdf:Description rdf:about="https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/"
+    dc:identifier="https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/"
+    dc:title="Hemp Heart Tabouli"
+    trackback:ping="https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/trackback/" />
+</rdf:RDF>-->
+</div><footer class="entry-footer"><p class="entry-meta"><span class="entry-categories">Filed Under: <a href="https://www.fooduzzi.com/category/appetizers/" rel="category tag">Appetizers</a>, <a href="https://www.fooduzzi.com/category/entree/" rel="category tag">Entree</a>, <a href="https://www.fooduzzi.com/category/food/" rel="category tag">Food</a>, <a href="https://www.fooduzzi.com/category/glutenfree/" rel="category tag">Gluten Free</a>, <a href="https://www.fooduzzi.com/category/snack/" rel="category tag">Snack</a>, <a href="https://www.fooduzzi.com/category/vegan/" rel="category tag">Vegan</a>, <a href="https://www.fooduzzi.com/category/vegetables/" rel="category tag">Vegetables</a>, <a href="https://www.fooduzzi.com/category/vegetarian/" rel="category tag">Vegetarian</a></span> </p></footer></article><h2 class="screen-reader-text">Reader Interactions</h2><div class="entry-comments" id="comments"><h3>Comments</h3><ol class="comment-list">
+	<li class="comment even thread-even depth-1" id="comment-19606">
+	<article itemprop="comment" itemscope itemtype="https://schema.org/Comment">
+
+		
+		<header class="comment-header">
+			<p class="comment-author" itemprop="author" itemscope itemtype="https://schema.org/Person">
+				<img alt='' src='https://secure.gravatar.com/avatar/4c3136874c21f6a3f5ee48f892bda305?s=120&#038;d=mm&#038;r=g' srcset='https://secure.gravatar.com/avatar/4c3136874c21f6a3f5ee48f892bda305?s=240&#038;d=mm&#038;r=g 2x' class='avatar avatar-120 photo' height='120' width='120' /><span itemprop="name"><a href="https://ramshacklepantry.com/" class="comment-author-link" rel="external nofollow" itemprop="url">Ben Myhre</a></span> <span class="says">says</span>			</p>
+
+			<p class="comment-meta"><time class="comment-time" datetime="2018-08-20T15:51:42+00:00" itemprop="datePublished"><a href="https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/#comment-19606" class="comment-time-link" itemprop="url">August 20, 2018 at 3:51 PM</a></time></p>		</header>
+
+		<div class="comment-content" itemprop="text">
+			
+			<p>This looks really good and interesting. I have never tried hemp hearts, but not I am going to have to give it a whirl. Remember to enjoy everything with moderation&#8230; even moderation. ;) Thanks for sharing with us!</p>
+		</div>
+
+		<div class="comment-reply"><a rel='nofollow' class='comment-reply-link' href='#comment-19606' onclick='return addComment.moveForm( "comment-19606", "19606", "respond", "10649" )' aria-label='Reply to Ben Myhre'>Reply</a></div>
+		
+	</article>
+	</li><!-- #comment-## -->
+</ol></div>	<div id="respond" class="comment-respond">
+		<h3 id="reply-title" class="comment-reply-title">Leave a Reply <small><a rel="nofollow" id="cancel-comment-reply-link" href="/2018/08/hemp-heart-tabouli/#respond" style="display:none;">Cancel reply</a></small></h3>			<form action="https://www.fooduzzi.com/wp-comments-post.php" method="post" id="commentform" class="comment-form" novalidate>
+				<p class="comment-notes"><span id="email-notes">Your email address will not be published.</span> Required fields are marked <span class="required">*</span></p><p class="comment-form-comment"><label for="comment">Comment</label> <textarea id="comment" name="comment" cols="45" rows="8" maxlength="65525" required="required"></textarea></p><p class="comment-form-author"><label for="author">Name <span class="required">*</span></label> <input id="author" name="author" type="text" value="" size="30" maxlength="245" required='required' /></p>
+<p class="comment-form-email"><label for="email">Email <span class="required">*</span></label> <input id="email" name="email" type="email" value="" size="30" maxlength="100" aria-describedby="email-notes" required='required' /></p>
+<p class="comment-form-url"><label for="url">Website</label> <input id="url" name="url" type="url" value="" size="30" maxlength="200" /></p>
+<p class="form-submit"><input name="submit" type="submit" id="submit" class="submit" value="Post Comment" /> <input type='hidden' name='comment_post_ID' value='10649' id='comment_post_ID' />
+<input type='hidden' name='comment_parent' id='comment_parent' value='0' />
+</p><p style="display: none;"><input type="hidden" id="akismet_comment_nonce" name="akismet_comment_nonce" value="1b58554b45" /></p><p style="display: none;"><input type="hidden" id="ak_js" name="ak_js" value="56"/></p>			</form>
+			</div><!-- #respond -->
+	</main><aside class="sidebar sidebar-primary widget-area" role="complementary" aria-label="Primary Sidebar" itemscope itemtype="https://schema.org/WPSideBar" id="genesis-sidebar-primary"><h2 class="genesis-sidebar-title screen-reader-text">Primary Sidebar</h2><section id="text-11" class="widget widget_text"><div class="widget-wrap">			<div class="textwidget"><img class="nopin" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2018/08/about-alexa-peduzzi-fooduzzi-plant-based-vegan.jpg" alt="alexa peduzzi"></a>
+
+<p class='about-fooduzzi'><br>I'm Alexa Peduzzi, that girl obsessed with cookies, oats, and veggies. Fooduzzi is the plant-based food blog. <a href="https://www.fooduzzi.com/category/food/">Click here</a> to discover tasty vegan meals and treats!</p></div>
+		</div></section>
+<section id="search-5" class="widget widget_search"><div class="widget-wrap"><form class="search-form" itemprop="potentialAction" itemscope itemtype="https://schema.org/SearchAction" method="get" action="https://www.fooduzzi.com/" role="search"><label class="search-form-label screen-reader-text" for="searchform-5c55e8fe6e0a34.32699570">Search this website</label><input class="search-form-input" type="search" itemprop="query-input" name="s" id="searchform-5c55e8fe6e0a34.32699570" placeholder="Search this website"><input class="search-form-submit" type="submit" value="Search"><meta itemprop="target" content="https://www.fooduzzi.com/?s={s}"></form></div></section>
+<section id="simple-social-icons-2" class="widget simple-social-icons"><div class="widget-wrap"><ul class="aligncenter"><li class="ssi-facebook"><a href="https://www.facebook.com/fooduzzi" target="_blank" rel="noopener noreferrer"><svg role="img" class="social-facebook" aria-labelledby="social-facebook-2"><title id="social-facebook-2">Facebook</title><use xlink:href="https://www.fooduzzi.com/wp-content/plugins/simple-social-icons/symbol-defs.svg#social-facebook"></use></svg></a></li><li class="ssi-instagram"><a href="https://www.instagram.com/fooduzzi" target="_blank" rel="noopener noreferrer"><svg role="img" class="social-instagram" aria-labelledby="social-instagram-2"><title id="social-instagram-2">Instagram</title><use xlink:href="https://www.fooduzzi.com/wp-content/plugins/simple-social-icons/symbol-defs.svg#social-instagram"></use></svg></a></li><li class="ssi-pinterest"><a href="https://www.pinterest.com/fooduzzi/" target="_blank" rel="noopener noreferrer"><svg role="img" class="social-pinterest" aria-labelledby="social-pinterest-2"><title id="social-pinterest-2">Pinterest</title><use xlink:href="https://www.fooduzzi.com/wp-content/plugins/simple-social-icons/symbol-defs.svg#social-pinterest"></use></svg></a></li><li class="ssi-twitter"><a href="https://www.twitter.com/fooduzzi" target="_blank" rel="noopener noreferrer"><svg role="img" class="social-twitter" aria-labelledby="social-twitter-2"><title id="social-twitter-2">Twitter</title><use xlink:href="https://www.fooduzzi.com/wp-content/plugins/simple-social-icons/symbol-defs.svg#social-twitter"></use></svg></a></li><li class="ssi-youtube"><a href="https://www.youtube.com/channel/UCqtcSDVBSlLukBoaS6EvS7Q" target="_blank" rel="noopener noreferrer"><svg role="img" class="social-youtube" aria-labelledby="social-youtube-2"><title id="social-youtube-2">YouTube</title><use xlink:href="https://www.fooduzzi.com/wp-content/plugins/simple-social-icons/symbol-defs.svg#social-youtube"></use></svg></a></li></ul></div></section>
+<section id="featured-post-2" class="widget featured-content featuredpost"><div class="widget-wrap"><h3 class="widgettitle widget-title">RECENT YUM</h3>
+<article class="post-11205 post type-post status-publish format-standard has-post-thumbnail category-life entry"><a href="https://www.fooduzzi.com/2019/02/lately-8/" class="alignleft" aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;><img width="150" height="150" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2019/01/popcorn-2-150x150.jpg" class="entry-image attachment-post" alt="Popcorn" itemprop="image" data-pin-description="Read about what we&#039;ve been up to lately! Sharing my new book recommendations, favorite restaurants, a new tool for social media, and so much more! || fooduzzi.com #fooduzzi #life #lately #lifestyle #vegan" /></a><header class="entry-header"><h4 class="entry-title" itemprop="headline"><a href="https://www.fooduzzi.com/2019/02/lately-8/">Lately</a></h4></header></article><article class="post-11185 post type-post status-publish format-standard has-post-thumbnail category-appetizers category-entree category-food category-vegan category-vegetables category-vegetarian entry"><a href="https://www.fooduzzi.com/2019/01/vegan-buffalo-tofu-tacos/" class="alignleft" aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;><img width="150" height="150" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2019/01/vegan-buffalo-tofu-tacos-3-150x150.jpg" class="entry-image attachment-post" alt="girl holding a vegan buffalo tofu taco" itemprop="image" data-pin-description="Vegan Buffalo Tofu Tacos: A filling, fresh, and spicy taco topped with all the things! Perfect for making-ahead so that mealtime is a breeze. || fooduzzi.com recipe #fooduzzi #tacos #vegan #buffalo #tofu" /></a><header class="entry-header"><h4 class="entry-title" itemprop="headline"><a href="https://www.fooduzzi.com/2019/01/vegan-buffalo-tofu-tacos/">Vegan Buffalo Tofu Tacos</a></h4></header></article><article class="post-11130 post type-post status-publish format-standard has-post-thumbnail category-bobs-red-mill category-entree category-food category-vegan category-vegetarian entry"><a href="https://www.fooduzzi.com/2019/01/homemade-whole-wheat-tortillas/" class="alignleft" aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;><img width="150" height="150" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2019/01/homemade-whole-wheat-flour-tortillas-7-150x150.jpg" class="entry-image attachment-post" alt="whole wheat flour tortillas in a basket" itemprop="image" data-pin-description="Homemade Whole Wheat Tortillas: Soft, chewy, foldable homemade whole wheat tortilla recipe that&#039;s as simple as it is delicious! You&#039;ll love using them for tacos, burritos, wraps, and more! || fooduzzi.com recipe #fooduzzi #tortillas #homemadebread #bobsredmill #mexican #vegan" /></a><header class="entry-header"><h4 class="entry-title" itemprop="headline"><a href="https://www.fooduzzi.com/2019/01/homemade-whole-wheat-tortillas/">Homemade Whole Wheat Tortillas</a></h4></header></article><article class="post-11115 post type-post status-publish format-standard has-post-thumbnail category-alexa-favorites category-entree category-favorites category-food category-glutenfree category-vegan category-vegetarian entry"><a href="https://www.fooduzzi.com/2019/01/baked-buffalo-tofu/" class="alignleft" aria-hidden=&quot;true&quot; tabindex=&quot;-1&quot;><img width="150" height="150" src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2019/01/easy-baked-buffalo-tofu-2-150x150.jpg" class="entry-image attachment-post" alt="easy baked buffalo tofu on a baking sheet" itemprop="image" data-pin-description="Easy Baked Buffalo Tofu: A simple, healthy, protein-packed vegan main! Perfect for dinners, bowls, salads, and more! || fooduzzi.com recipe #vegan #glutenfree #tofu #fooduzzi" /></a><header class="entry-header"><h4 class="entry-title" itemprop="headline"><a href="https://www.fooduzzi.com/2019/01/baked-buffalo-tofu/">Easy Baked Buffalo Tofu</a></h4></header></article></div></section>
+<section id="text-9" class="widget widget_text"><div class="widget-wrap">			<div class="textwidget"><a href="https://www.fooduzzi.com/2016/08/easy-vegan-on-the-go-lunches/"><img src="https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2016/09/easy-vegan-lunches.jpg" class="nopin"></a></div>
+		</div></section>
+<section id="bloomwidget-3" class="widget widget_bloomwidget"><div class="widget-wrap">
+				<div class='et_bloom_widget_content et_bloom_make_form_visible et_bloom_optin et_bloom_optin_6' style='display: none;'>
+					<style type="text/css">.et_bloom .et_bloom_optin_6 .et_bloom_form_content { background-color: #ededed !important; } .et_bloom .et_bloom_optin_6 .et_bloom_form_container .et_bloom_form_header { background-color: #ffffff !important; } .et_bloom .et_bloom_optin_6 .carrot_edge .et_bloom_form_content:before { border-top-color: #ffffff !important; } .et_bloom .et_bloom_optin_6 .carrot_edge.et_bloom_form_right .et_bloom_form_content:before, .et_bloom .et_bloom_optin_6 .carrot_edge.et_bloom_form_left .et_bloom_form_content:before { border-top-color: transparent !important; border-left-color: #ffffff !important; }
+						@media only screen and ( max-width: 767px ) {.et_bloom .et_bloom_optin_6 .carrot_edge.et_bloom_form_right .et_bloom_form_content:before, .et_bloom .et_bloom_optin_6 .carrot_edge.et_bloom_form_left .et_bloom_form_content:before { border-top-color: #ffffff !important; border-left-color: transparent !important; }
+						}.et_bloom .et_bloom_optin_6 .et_bloom_form_content button { background-color: #f17a82 !important; } .et_bloom .et_bloom_optin_6 .et_bloom_form_content button { background-color: #f17a82 !important; } .et_bloom .et_bloom_optin_6 .et_bloom_form_container h2, .et_bloom .et_bloom_optin_6 .et_bloom_form_container h2 span, .et_bloom .et_bloom_optin_6 .et_bloom_form_container h2 strong { font-family: "Roboto", Helvetica, Arial, Lucida, sans-serif; }.et_bloom .et_bloom_optin_6 .et_bloom_form_container p, .et_bloom .et_bloom_optin_6 .et_bloom_form_container p span, .et_bloom .et_bloom_optin_6 .et_bloom_form_container p strong, .et_bloom .et_bloom_optin_6 .et_bloom_form_container form input, .et_bloom .et_bloom_optin_6 .et_bloom_form_container form button span { font-family: "Roboto", Helvetica, Arial, Lucida, sans-serif; } </style>
+					<div class='et_bloom_form_container with_edge carrot_edge et_bloom_rounded et_bloom_form_text_dark'>
+						
+			<div class="et_bloom_form_container_wrapper clearfix">
+				<div class="et_bloom_header_outer">
+					<div class="et_bloom_form_header et_bloom_header_text_dark">
+						
+						<div class="et_bloom_form_text">
+						<h2 style="text-align: center;">Want a free eCookbook?</h2><p style="text-align: center;">Get my best healthy, gluten free, and plant-based recipes in a free eCookbook by subscribing to email updates!</p>
+					</div>
+						
+					</div>
+				</div>
+				<div class="et_bloom_form_content et_bloom_2_fields et_bloom_bottom_stacked">
+					
+					
+					<form method="post" class="clearfix">
+						<p class="et_bloom_popup_input et_bloom_subscribe_name">
+								<input placeholder="First Name" maxlength="50">
+							</p>
+						<p class="et_bloom_popup_input et_bloom_subscribe_email">
+							<input placeholder="Email">
+						</p>
+
+						<button data-optin_id="optin_6" data-service="mailchimp" data-list_id="91657c27d5" data-page_id="10649" data-account="peduzzia" data-disable_dbl_optin="" class="et_bloom_submit_subscription">
+							<span class="et_bloom_subscribe_loader"></span>
+							<span class="et_bloom_button_text et_bloom_button_text_color_light">SUBSCRIBE!</span>
+						</button>
+					</form>
+					<div class="et_bloom_success_container">
+						<span class="et_bloom_success_checkmark"></span>
+					</div>
+					<h2 class="et_bloom_success_message">Thanks! Check your email for the confirmation!</h2>
+					
+				</div>
+			</div>
+			<span class="et_bloom_close_button"></span>
+					</div>
+				</div></div></section>
+<section id="custom_html-2" class="widget_text widget widget_custom_html"><div class="widget_text widget-wrap"><div class="textwidget custom-html-widget"><style>  
+  .syb-container {
+    width: 100%;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    overflow: hidden;
+    background: #222;
+    color: #fff;
+    transition: all 400ms ease-in-out;
+    padding: 10rem 1.5rem;
+    -webkit-font-smoothing: subpixel-antialiased;
+    position: relative;
+    font-family: "Roboto";
+  }
+
+  .syb-container:hover {
+    background: rgba(0, 0, 0, 0);
+    box-shadow: 0 0 80px rgba(0, 0, 0, 0.15);
+    color: #fff;
+  }
+
+  .syb-container:hover .syb-button {
+    background: #fff;
+    color: #ff0080;
+  }
+
+  .syb-background {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(45deg, blue, #ff0080);
+    z-index: -1;
+  }
+
+  .syb-heading {
+    font-family: "Playfair Display";
+    font-weight: 700;
+    font-size: 40px;
+    margin-bottom: 1rem;
+    line-height: 135%;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .syb-paragraph {
+    font-size: 17px;
+    margin-bottom: 20px;
+    font-weight: 300;
+    line-height: 150%;
+  }
+
+  .syb-button {
+    font-size: 16px;
+    letter-spacing: 0.5px;
+    display: inline-block;
+    border: 0;
+    text-decoration: none;
+    padding: 15px 36px;
+    background: #f17a82;
+    color: #fff;
+    text-transform: uppercase;
+    font-weight: 400;
+    transition: all 400ms ease-in-out;
+  }
+
+  .syb-container:hover .syb-button:hover {
+    background: #fff;
+    box-shadow: 0 0 80px rgba(0, 0, 0, 0.4);
+    color: blue;
+  }
+
+  .syb-image-link {
+    text-decoration: none;
+    border: 0;
+  }
+</style>
+
+<div class="syb-container">
+	<div class="syb-heading" id="sybHeading">Want to start your own blog?</div>
+	<div class="syb-paragraph" id="sybParagraph">Mark and I made a tutorial to teach you how to set it up...all in less than 10 minutes! Yes, for real. Get resources, inspiration, instruction, and more.</div>
+	<a href="https://startyourblog.co/?utm_source=fooduzzi&utm_medium=banner&utm_content=1" class="syb-button" id="sybButton" target="_blank">Show Me How</a>
+	<div class="syb-background"></div>
+</div></div></div></section>
+</aside></div></div>
+	<div class="site-footer"><div class="wrap"><p>© Fooduzzi LLC, 2017 || <a href="https://fooduzzi.com/privacy-policy/">Privacy Policy</a> || <a href="mailto:fooduzzi@gmail.com">Get in Touch</a></p></div></div>
+
+</div><div class="et_social_pin_images_outer">
+					<div class="et_social_pinterest_window">
+						<div class="et_social_modal_header"><h3>Pin It on Pinterest</h3><span class="et_social_close"></span></div>
+						<div class="et_social_pin_images" data-permalink="https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/" data-title="Hemp Heart Tabouli" data-post_id="10649"></div>
+					</div>
+				</div><div class="et_social_sidebar_networks et_social_visible_sidebar et_social_no_animation et_social_animated et_social_circle et_social_sidebar_border et_social_mobile_on et_social_sidebar_networks_right">
+					
+					<ul class="et_social_icons_container"><li class="et_social_facebook">
+									<a href="http://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;t=Hemp%20Heart%20Tabouli" class="et_social_share" rel="nofollow" data-social_name="facebook" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_facebook"></i>
+										
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_pinterest">
+									<a href="#" class="et_social_share_pinterest" rel="nofollow" data-social_name="pinterest" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_pinterest"></i>
+										
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_twitter">
+									<a href="http://twitter.com/share?text=Hemp%20Heart%20Tabouli&#038;url=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;via=fooduzzi" class="et_social_share" rel="nofollow" data-social_name="twitter" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_twitter"></i>
+										
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_buffer">
+									<a href="https://bufferapp.com/add?url=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;title=Hemp%20Heart%20Tabouli" class="et_social_share" rel="nofollow" data-social_name="buffer" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_buffer"></i>
+										
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_gmail">
+									<a href="https://mail.google.com/mail/u/0/?view=cm&#038;fs=1&#038;su=Hemp%20Heart%20Tabouli&#038;body=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;ui=2&#038;tf=1" class="et_social_share" rel="nofollow" data-social_name="gmail" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_gmail"></i>
+										
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_reddit">
+									<a href="http://www.reddit.com/submit?url=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;title=Hemp%20Heart%20Tabouli" class="et_social_share" rel="nofollow" data-social_name="reddit" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_reddit"></i>
+										
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_tumblr">
+									<a href="https://www.tumblr.com/share?v=3&#038;u=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;t=Hemp%20Heart%20Tabouli" class="et_social_share" rel="nofollow" data-social_name="tumblr" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_tumblr"></i>
+										
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li></ul>
+					<span class="et_social_hide_sidebar et_social_icon"></span>
+				</div><div class="et_social_mobile_button"></div>
+					<div class="et_social_mobile et_social_fadein">
+						<div class="et_social_heading">Share This</div>
+						<span class="et_social_close"></span>
+						<div class="et_social_networks et_social_simple et_social_rounded et_social_left">
+							<ul class="et_social_icons_container"><li class="et_social_facebook">
+									<a href="http://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;t=Hemp%20Heart%20Tabouli" class="et_social_share" rel="nofollow" data-social_name="facebook" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_facebook"></i>
+										<div class="et_social_network_label"><div class="et_social_networkname">Facebook</div></div>
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_pinterest">
+									<a href="#" class="et_social_share_pinterest" rel="nofollow" data-social_name="pinterest" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_pinterest"></i>
+										<div class="et_social_network_label"><div class="et_social_networkname">Pinterest</div></div>
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_twitter">
+									<a href="http://twitter.com/share?text=Hemp%20Heart%20Tabouli&#038;url=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;via=fooduzzi" class="et_social_share" rel="nofollow" data-social_name="twitter" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_twitter"></i>
+										<div class="et_social_network_label"><div class="et_social_networkname">Twitter</div></div>
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_buffer">
+									<a href="https://bufferapp.com/add?url=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;title=Hemp%20Heart%20Tabouli" class="et_social_share" rel="nofollow" data-social_name="buffer" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_buffer"></i>
+										<div class="et_social_network_label"><div class="et_social_networkname">Buffer</div></div>
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_gmail">
+									<a href="https://mail.google.com/mail/u/0/?view=cm&#038;fs=1&#038;su=Hemp%20Heart%20Tabouli&#038;body=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;ui=2&#038;tf=1" class="et_social_share" rel="nofollow" data-social_name="gmail" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_gmail"></i>
+										<div class="et_social_network_label"><div class="et_social_networkname">Gmail</div></div>
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_reddit">
+									<a href="http://www.reddit.com/submit?url=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;title=Hemp%20Heart%20Tabouli" class="et_social_share" rel="nofollow" data-social_name="reddit" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_reddit"></i>
+										<div class="et_social_network_label"><div class="et_social_networkname">reddit</div></div>
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li><li class="et_social_tumblr">
+									<a href="https://www.tumblr.com/share?v=3&#038;u=https%3A%2F%2Fwww.fooduzzi.com%2F2018%2F08%2Fhemp-heart-tabouli%2F&#038;t=Hemp%20Heart%20Tabouli" class="et_social_share" rel="nofollow" data-social_name="tumblr" data-post_id="10649" data-social_type="share" data-location="sidebar">
+										<i class="et_social_icon et_social_icon_tumblr"></i>
+										<div class="et_social_network_label"><div class="et_social_networkname">Tumblr</div></div>
+										
+										<span class="et_social_overlay"></span>
+									</a>
+								</li></ul>
+						</div>
+					</div>
+					<div class="et_social_mobile_overlay"></div><style type="text/css" media="screen"> #simple-social-icons-2 ul li a, #simple-social-icons-2 ul li a:hover, #simple-social-icons-2 ul li a:focus { background-color: #333333 !important; border-radius: 3px; color: #ffffff !important; border: 0px #ffffff solid !important; font-size: 18px; padding: 9px; }  #simple-social-icons-2 ul li a:hover, #simple-social-icons-2 ul li a:focus { background-color: #f17a82 !important; border-color: #ffffff !important; color: #ffffff !important; }  #simple-social-icons-2 ul li a:focus { outline: 1px dotted #f17a82 !important; }</style><link rel='stylesheet' id='et-gf-roboto-css'  href='https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic&#038;subset=latin,cyrillic-ext,latin-ext,cyrillic,greek-ext,greek,vietnamese' type='text/css' media='all' />
+<link rel='stylesheet' id='et_bloom-css-css'  href='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/bloom/css/style.css?ver=1.2.16' type='text/css' media='all' />
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/monarch/js/idle-timer.min.js?ver=1.3.18'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var monarchSettings = {"ajaxurl":"https:\/\/www.fooduzzi.com\/wp-admin\/admin-ajax.php","pageurl":"https:\/\/www.fooduzzi.com\/2018\/08\/hemp-heart-tabouli\/","stats_nonce":"bc8310e1e4","share_counts":"76aa4c5d09","follow_counts":"946987ede8","total_counts":"2d813bc675","media_single":"e5403f2f75","media_total":"fa26449611","generate_all_window_nonce":"f305dbab8d","no_img_message":"No images available for sharing on this page"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/monarch/js/custom.js?ver=1.3.18'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-includes/js/comment-reply.min.js?ver=4.9.9'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-includes/js/hoverIntent.min.js?ver=1.8.1'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/themes/genesis/lib/js/menu/superfish.min.js?ver=1.7.5'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/themes/genesis/lib/js/menu/superfish.args.min.js?ver=2.8.0'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/themes/genesis/lib/js/skip-links.min.js?ver=2.8.0'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/themes/twenty-seven-pro/js/jquery.matchHeight.js?ver=0.5.2'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var genesis_responsive_menu = {"mainMenu":"Menu","menuIconClass":"ionicons-before ion-drag","subMenu":"Menu","subMenuIconsClass":"ionicons-before ion-ios-arrow-down","menuClasses":{"combine":[".nav-primary",".nav-secondary"],"others":[]}};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/themes/twenty-seven-pro/js/responsive-menus.min.js?ver=1.1'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-includes/js/wp-embed.min.js?ver=4.9.9'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/bloom/js/jquery.uniform.min.js?ver=1.2.16'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var bloomSettings = {"ajaxurl":"https:\/\/www.fooduzzi.com\/wp-admin\/admin-ajax.php","pageurl":"https:\/\/www.fooduzzi.com\/2018\/08\/hemp-heart-tabouli\/","stats_nonce":"4824ba9d7b","subscribe_nonce":"b3d7990df9","is_user_logged_in":"not_logged"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/bloom/js/custom.js?ver=1.2.16'></script>
+<script type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/bloom/js/idle-timer.min.js?ver=1.2.16'></script>
+<script async="async" type='text/javascript' src='https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/plugins/akismet/_inc/form.js?ver=4.1'></script>
+</body></html>

--- a/test/microdata_test.exs
+++ b/test/microdata_test.exs
@@ -73,6 +73,234 @@ defmodule MicrodataTest do
               }
             ],
             types: MapSet.new(["http://schema.org/Recipe"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/logo"]),
+                value: "https://static.seriouseats.com/1/braestar/live/img/logo-color-240x190.png"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/sameAs"]),
+                value: "https://www.facebook.com/seriouseats"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/sameAs"]),
+                value: "https://twitter.com/seriouseats"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/sameAs"]),
+                value: "https://plus.google.com/+seriouseats/posts"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/sameAs"]),
+                value: "https://pinterest.com/seriouseats"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/sameAs"]),
+                value: "https://instagram.com/seriouseats/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/sameAs"]),
+                value: "https://www.youtube.com/user/SeriousEats"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/url"]),
+                value: "https://www.seriouseats.com"
+              }
+            ],
+            types: MapSet.new(["http://schema.org/Organization"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value: "https://www.seriouseats.com/recipes/"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 1
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value: "https://www.seriouseats.com/recipes/topics/ingredient"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 2
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value:
+                        "https://www.seriouseats.com/recipes/topics/ingredient/meats-and-poultry"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 3
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value:
+                        "https://www.seriouseats.com/recipes/topics/ingredient/meats-and-poultry/other-meats"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 4
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              }
+            ],
+            types: MapSet.new(["http://schema.org/BreadcrumbList"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value: "https://www.seriouseats.com/recipes/"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 1
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value: "https://www.seriouseats.com/recipes/topics/meal"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 2
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value: "https://www.seriouseats.com/recipes/topics/meal/mains"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 3
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              }
+            ],
+            types: MapSet.new(["http://schema.org/BreadcrumbList"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value: "https://www.seriouseats.com/recipes/"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 1
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value: "https://www.seriouseats.com/recipes/topics/method"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 2
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value: "https://www.seriouseats.com/recipes/topics/method/sous-vide"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 3
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              }
+            ],
+            types: MapSet.new(["http://schema.org/BreadcrumbList"])
           }
         ]
       }
@@ -499,6 +727,571 @@ defmodule MicrodataTest do
                   reason: :no_items,
                   metadata: %{input: File.read!(@empty_file)}
                 }}
+    end
+  end
+
+  @tag runnable: true
+  describe "mixed & nested annotations" do
+    @recipe_url "https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/"
+    @recipe_file "./test/_cache/html-recipe-with-ld-and-nesting.html"
+
+    setup do
+      doc = %Microdata.Document{
+        items: [
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/about/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "About"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/welcome-to-fooduzzi/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Start Here"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/food/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Recipes"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/food-index/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Recipe Index"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/breakfast/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Breakfast"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/oats/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Oats"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/smoothies/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Smoothies"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/appetizers/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Appetizers"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/entree/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Entree"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/salad/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Salad"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/sandwiches/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Sandwiches"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/soup/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Soup"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/sauces/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Sauces"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/snack/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Snack"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/dessert/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Dessert"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: ""
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Dietary Restriction"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/vegan/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Vegan"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/glutenfree/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Gluten Free"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/vegetarian/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Vegetarian"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/how-tos/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Kitchen How-Tos"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/favorites/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Favorites"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/favorites/alexa-favorites/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Alexa Favorites"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/favorites/reader-favorites/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Reader Favorites"
+              }
+            ],
+            types: MapSet.new(["https://schema.org/SiteNavigationElement"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/life/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Life"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/category/life/travel/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Vegan Travel"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: "https://www.fooduzzi.com/work-with-me/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Work with Me"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/url"]),
+                value: ""
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/name"]),
+                value: "Contact"
+              }
+            ],
+            types: MapSet.new(["https://schema.org/SiteNavigationElement"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/name"]),
+                value: "Hemp Heart Tabouli"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/author"]),
+                value: "Fooduzzi"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/url"]),
+                value: "https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/image"]),
+                value:
+                  "https://www.fooduzzi.com/wp-content/uploads/2018/08/hemp-heart-tabouli-7.jpg"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/prepTime"]),
+                value: "10m"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeYield"]),
+                value: "serves 4-6"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/totalTime"]),
+                value: "0h 10m"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/description"]),
+                value:
+                  "A simple, no-cook vegan tabouli made with hemp hearts! A protein- and nutrient-packed snack, lunch, or side!"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeIngredient"]),
+                value: "2 cups packed parsley, minced"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeIngredient"]),
+                value: "5 large mint leaves, minced"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeIngredient"]),
+                value: "1/2 cup hemp hearts"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeIngredient"]),
+                value: "juice of 1-2 small lemons"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeIngredient"]),
+                value: "1 roma tomato, chopped"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeIngredient"]),
+                value: "1 large green onion, minced"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeIngredient"]),
+                value: "1/4 large english cucumber, chopped"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeIngredient"]),
+                value: "1/4 tsp. allspice, optional for toasty flavor"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeIngredient"]),
+                value: "1 Tbsp. olive oil"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeIngredient"]),
+                value: "salt + pepper"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/recipeInstructions"]),
+                value:
+                  "Mix all of your ingredients in a medium bowl. Season with salt and pepper to taste and enjoy!"
+              }
+            ],
+            types: MapSet.new(["http://schema.org/Recipe"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/headline"]),
+                value: "Fooduzzi"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/description"]),
+                value: "the plant-based food blog"
+              }
+            ],
+            types: MapSet.new(["https://schema.org/WPHeader"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/headline"]),
+                value: "Hemp Heart Tabouli"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/datePublished"]),
+                value: "August 20, 2018"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/author"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["https://schema.org/url"]),
+                      value: "https://www.fooduzzi.com/author/peduzziagmail-com/"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["https://schema.org/name"]),
+                      value: "Alexa [fooduzzi.com]"
+                    }
+                  ],
+                  types: MapSet.new(["https://schema.org/Person"])
+                }
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/text"]),
+                value:
+                  "If you have a garden that is totally overgrown with parsley, mint, and tomatoes, this recipe is for you! This recipe is  also for you if you’re a fan of delicious flavor. (name that show) I. Love. Tabouli. Or tabbouleh. However you spell it, I love it. There’s a fabulous Mediterranean restaurant chain here in Pittsburgh (Aladdin’s), and they have the best tabouli ever. They add it to this salad that I  swear I’m not going to get again every time I go. But alas, I end up ordering it again and it never ever ever disappoints. Tabouli is typically made with bulgur wheat, buuuut I wanted to lay off the wheat a bit. I’ve been eating a ton of wheat in the form of bread, pizza, and pasta recently. Not like it’s a bad thing in moderation. But I am desperately missing some moderation in my life. And because I’ve been working out more recently, I’ve been looking for ways to increase my protein intake. And one of my favorite plant-based protein sources is…the hemp heart! So, uh, what are hemp hearts? Fab question, my dear. They are the creamy, nutty, delicious little seeds from the hemp plant! Yes , that hemp plant.  No , they won’t get you high. You can actually buy them in pretty much any grocery store. Typically over by the oats / cereals or over by the nuts and seeds. But they’re awesome. 3 Tbsp. of hemp hearts have 10g protein. Plus omega-3s and omega-6s for healthy hearts and brains, iron, manganese, thiamine, and lots of other goodness. They’re a cute little nutritional powerhouse, and they’re delicious in this tabouli. But honestly, how could they  not be delicious in this tabouli when there are ingredients like copious amounts of parsley, a bit of mint, some lemon juice, a bit of veggies, and a wee bit of seasoning? This is the kind of dish that just  shines in its simplicity. It’s stupidly simple, but ridiculously flavorful and addictive. Wahoo! I highly suggest enjoying this tabouli in salads , on cheese plates , with crackers , in pitas, or on its own with a fork or spoon. I love it. You’ll love it. I know it. Hemp Heart Tabouli From Fooduzzi at https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/ https://www.fooduzzi.com/wp-content/uploads/2018/08/hemp-heart-tabouli-7.jpg Prep: 10m Yield: serves 4-6 Total: 0h 10m A simple, no-cook vegan tabouli made with hemp hearts! A protein- and nutrient-packed snack, lunch, or side! You'll Need... 2 cups packed parsley, minced 5 large mint leaves, minced 1/2 cup hemp hearts juice of 1-2 small lemons 1 roma tomato, chopped 1 large green onion, minced 1/4 large english cucumber, chopped 1/4 tsp. allspice, optional for toasty flavor 1 Tbsp. olive oil salt + pepper Directions Mix all of your ingredients in a medium bowl. Season with salt and pepper to taste and enjoy! Generated with ♥︎ by Matcha Print Join the Fooduzzi Fam! I'll send you healthy takes on classic recipes, delectable recipe roundups, and more updates on my growing blog. You'll also receive a free eCookbook featuring my best recipes! Send me healthy recipes! Check your email to confirm and to download your free eCookbook!"
+              }
+            ],
+            types: MapSet.new(["https://schema.org/CreativeWork"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/potentialAction"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["https://schema.org/query-input"]),
+                      value: ""
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["https://schema.org/target"]),
+                      value: "https://www.fooduzzi.com/?s={s}"
+                    }
+                  ],
+                  types: MapSet.new(["https://schema.org/SearchAction"])
+                }
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/image"]),
+                value:
+                  "https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2019/01/popcorn-2-150x150.jpg"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/headline"]),
+                value: "Lately"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/image"]),
+                value:
+                  "https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2019/01/vegan-buffalo-tofu-tacos-3-150x150.jpg"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/headline"]),
+                value: "Vegan Buffalo Tofu Tacos"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/image"]),
+                value:
+                  "https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2019/01/homemade-whole-wheat-flour-tortillas-7-150x150.jpg"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/headline"]),
+                value: "Homemade Whole Wheat Tortillas"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/image"]),
+                value:
+                  "https://swj0y6xl9l-flywheel.netdna-ssl.com/wp-content/uploads/2019/01/easy-baked-buffalo-tofu-2-150x150.jpg"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/headline"]),
+                value: "Easy Baked Buffalo Tofu"
+              }
+            ],
+            types: MapSet.new(["https://schema.org/WPSideBar"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["https://schema.org/comment"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["https://schema.org/author"]),
+                      value: %Microdata.Item{
+                        id: nil,
+                        properties: [
+                          %Microdata.Property{
+                            names: MapSet.new(["https://schema.org/name"]),
+                            value: "Ben Myhre"
+                          },
+                          %Microdata.Property{
+                            names: MapSet.new(["https://schema.org/url"]),
+                            value: "https://ramshacklepantry.com/"
+                          }
+                        ],
+                        types: MapSet.new(["https://schema.org/Person"])
+                      }
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["https://schema.org/datePublished"]),
+                      value: "August 20, 2018 at 3:51 PM"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["https://schema.org/url"]),
+                      value: "https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/#comment-19606"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["https://schema.org/text"]),
+                      value:
+                        "This looks really good and interesting. I have never tried hemp hearts, but not I am going to have to give it a whirl. Remember to enjoy everything with moderation… even moderation. ;) Thanks for sharing with us!"
+                    }
+                  ],
+                  types: MapSet.new(["https://schema.org/Comment"])
+                }
+              }
+            ],
+            types: MapSet.new(["https://schema.org/WebPage"])
+          },
+          %Microdata.Item{
+            id: "#person",
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/name"]),
+                value: "Alexa [fooduzzi.com]"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/sameAs"]),
+                value: "https://www.facebook.com/pages/Fooduzzi/761543773962006"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/sameAs"]),
+                value: "https://instagram.com/fooduzzi/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/sameAs"]),
+                value: "https://www.pinterest.com/fooduzzi/"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/sameAs"]),
+                value: "https://twitter.com/fooduzzi"
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/url"]),
+                value: "https://www.fooduzzi.com/"
+              }
+            ],
+            types: MapSet.new(["http://schema.org/Person"])
+          },
+          %Microdata.Item{
+            id: nil,
+            properties: [
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value: "https://www.fooduzzi.com/"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 1
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              },
+              %Microdata.Property{
+                names: MapSet.new(["http://schema.org/itemListElement"]),
+                value: %Microdata.Item{
+                  id: nil,
+                  properties: [
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/item"]),
+                      value: "https://www.fooduzzi.com/2018/08/hemp-heart-tabouli/"
+                    },
+                    %Microdata.Property{
+                      names: MapSet.new(["http://schema.org/position"]),
+                      value: 2
+                    }
+                  ],
+                  types: MapSet.new(["http://schema.org/ListItem"])
+                }
+              }
+            ],
+            types: MapSet.new(["http://schema.org/BreadcrumbList"])
+          }
+        ]
+      }
+
+      {:ok, doc: doc}
+    end
+
+    test "converts from text", %{doc: doc} do
+      assert @recipe_file |> File.read!() |> Microdata.parse() == {:ok, doc}
+    end
+
+    test "converts from file", %{doc: doc} do
+      assert Microdata.parse(file: @recipe_file) == {:ok, doc}
+    end
+
+    @tag :remote
+    test "converts from url", %{doc: doc} do
+      assert Microdata.parse(url: @recipe_url) == {:ok, doc}
     end
   end
 end


### PR DESCRIPTION
Two fixes:

#### Sub-items were being too aggressively filtered.

Example: https://www.fooduzzi.com/2018/01/vegan-marinara-farro-roasted-broccoli-chickpeas/

With the former XPath selector, the `Recipe`, `WPHeader, `WPSidebar`, etc items were being filtered out of the result because they were children of an `itemscope`.

This change returns these non-property child items in parsed output, while still filtering the `Comment`s and `Person`s referenced as `WebPage` properties from the top-level return.

#### HTML & JSON parsing strategies were `OR` vs `AND`

Example: https://www.fooduzzi.com/2019/01/vegan-italian-chopped-salad/

With the former `Enum.find_value`, we stopped execution on the first successful strategy.

With the new `Enum.flat_map`, we check both HTML & JSON for data.

n.b. there is a higher risk of duplicate items